### PR TITLE
CHORE: Update currency-related dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Following the release of the advisory (see above), we have updated dependencies 
 #### If you cloned/downloaded PolyBot prior to this commit, please update ASAP!
 
 *Note: `aiohttp` is a library used by `discord.py`, which is the basis for most Python-based bots for Discord, including `PolyBot`*.  
-### To grab the updates
+### To grab the updates (Applicable for all kinds of dependency updates)
 1. Perform `git pull`
 2. Grab the new dependencies  
     - For Global Environment:  

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ colorama==0.4.4
 discord.py==1.6.0
 distlib==0.3.1
 filelock==3.0.12
-forex-python==1.5
+forex-python==1.6
 identify==1.5.13
 idna==2.10
 lxml==4.6.2


### PR DESCRIPTION
This update is in response to the newly reported issue with PolyBot not being able to perform currency conversions anymore.
The `forex-python` library that PolyBot relies on is noted to have had a new version, with no noted changes in conversion API. It is, however, noted that rates-errors may occur pre-1.6, and thus, this pull request bumps the required version of `forex-python` from 1.5 to 1.6, in hopes of resolving these errors.

NOTE: PLEASE RUN `pip install -r requirements.txt` to update your dependencies, after pulling!